### PR TITLE
Add files via upload

### DIFF
--- a/src/Interface/ukuimenuinterface.cpp
+++ b/src/Interface/ukuimenuinterface.cpp
@@ -223,7 +223,7 @@ QVector<QStringList> UkuiMenuInterface::createAppInfoVector()
         bool is_owned=false;
         for(int j=0;j<vector.size();j++)
         {
-            if(matchingAppCategories(desktopfpList.at(i),vector.at(j)))//有对应分类
+            if(matchingAppCategories(desktopfpList.at(i),vector.at(j))&&!is_owned)//有对应分类,且未匹配成功过
             {
                 is_owned=true;
                 appInfoList.append(QString::number(j));


### PR DESCRIPTION
#124号，解决了“部分应用有重复出现在不同分类里”的问题，createAppInfoVector()方法会多次匹配
问题原因：某些desktop文件中Categories有多个可匹配成功的字段
解决思路：同一个desktop文件，一旦匹配成功就不继续匹配
更新位置：第226行代码